### PR TITLE
Make RestartProcessThatTerminatesAfterFileChange more reliable

### DIFF
--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using Xunit;
 
 namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
@@ -79,6 +80,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                 // Then wait for it to restart when we change a file
                 using (var wait = new WaitForFileToChange(scenario.StartedFile))
                 {
+                    // On Unix the file write time is in 1s increments;
+                    // if we don't wait, there's a chance that the polling
+                    // watcher will not detect the change
+                    Thread.Sleep(1000);
+
                     var fileToChange = Path.Combine(scenario.TestAppFolder, "Program.cs");
                     var programCs = File.ReadAllText(fileToChange);
                     File.WriteAllText(fileToChange, programCs);

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             }
         }
 
-        [Fact(Skip = "aspnet/dotnet-watch#98")]
+        [Fact]
         public void RestartProcessThatTerminatesAfterFileChange()
         {
             using (var scenario = new NoDepsAppScenario())

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Waiters.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Waiters.cs
@@ -44,6 +44,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public static void WaitForProcessToStop(int processId, TimeSpan timeout, bool expectedToStop, string errorMessage)
         {
+            Console.WriteLine($"Waiting for process {processId} to stop...");
+
             Process process = null;
 
             try
@@ -52,8 +54,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             }
             catch (Exception e)
             {
-                Console.WriteLine("Could not get process id:");
-                Console.WriteLine(e);
+                // If we expect the process to stop, then it might have stopped already
+                if (!expectedToStop)
+                {
+                    Console.WriteLine($"Could not find process {processId}: {e}");
+                }
             }
 
             var watch = new Stopwatch();
@@ -62,6 +67,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             {
                 if (process == null || process.HasExited)
                 {
+                    Console.WriteLine($"Process {processId} is no longer running");
                     break;
                 }
                 Thread.Sleep(500);


### PR DESCRIPTION
Fixes https://github.com/aspnet/dotnet-watch/issues/98

I believe the thread sleep will help on Windows too.

please review @moozzyk 