### PR TITLE
Fix null ref exception when referencing csproj

### DIFF
--- a/src/Microsoft.DotNet.Watcher.Core/Internal/Implementation/Project.cs
+++ b/src/Microsoft.DotNet.Watcher.Core/Internal/Implementation/Project.cs
@@ -48,7 +48,10 @@ namespace Microsoft.DotNet.Watcher.Core.Internal
             if (File.Exists(projectLockJsonPath))
             {
                 var lockFile = LockFileReader.Read(projectLockJsonPath, designTime: false);
-                ProjectDependencies = lockFile.ProjectLibraries.Select(dep => GetProjectRelativeFullPath(dep.Path)).ToList();
+                ProjectDependencies = lockFile.ProjectLibraries
+                    .Where(dep => !string.IsNullOrEmpty(dep.Path)) // The dependency path is null for xproj -> csproj reference
+                    .Select(dep => GetProjectRelativeFullPath(dep.Path))
+                    .ToList();
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/aspnet/dotnet-watch/issues/136

The issue is that for xproj files we don't have a project path even though they appear as project references. The fix is to ignore those projects. The consequence is that dotnet watch will not restart the app when code files change in csproj files.

Please review @BrennanConroy 