### PR TITLE
Null ref fix + more logging

### DIFF
--- a/src/Microsoft.DotNet.Watcher.Core/DotNetWatcher.cs
+++ b/src/Microsoft.DotNet.Watcher.Core/DotNetWatcher.cs
@@ -93,6 +93,7 @@ namespace Microsoft.DotNet.Watcher.Core
 
                     cancellationToken.ThrowIfCancellationRequested();
 
+                    string changedFile;
                     if (finishedTaskIndex == 0)
                     {
                         // This is the dotnet task
@@ -109,13 +110,17 @@ namespace Microsoft.DotNet.Watcher.Core
 
                         _logger.LogInformation("Waiting for a file to change before restarting dotnet...");
                         // Now wait for a file to change before restarting dotnet
-                        await WaitForProjectFileToChangeAsync(projectFile, cancellationToken);
+                        changedFile = await WaitForProjectFileToChangeAsync(projectFile, cancellationToken);
                     }
                     else
                     {
                         // This is a file watcher task
-                        string changedFile = fileWatchingTask.Result;
-                        _logger.LogInformation($"File changed: {fileWatchingTask.Result}");
+                        changedFile = fileWatchingTask.Result;
+                    }
+
+                    if (!string.IsNullOrEmpty(changedFile))
+                    {
+                        _logger.LogInformation($"File changed: {changedFile}");
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Watcher.Core/Internal/Implementation/Project.cs
+++ b/src/Microsoft.DotNet.Watcher.Core/Internal/Implementation/Project.cs
@@ -35,7 +35,8 @@ namespace Microsoft.DotNet.Watcher.Core.Internal
             }
             else
             {
-                filesToWatch.AddRange(runtimeProject.Files.ResourceFiles.Values);
+                // For resource files the key is the name of the file, not the value
+                filesToWatch.AddRange(runtimeProject.Files.ResourceFiles.Keys);
             }
 
             filesToWatch.AddRange(runtimeProject.Files.SharedFiles);


### PR DESCRIPTION
Fixes: https://github.com/aspnet/dotnet-watch/issues/139

- Fix a NullRef exception that was happening when projects have resx files
- Print the changed file name in all cases

Please review @BrennanConroy @moozzyk 